### PR TITLE
Agregue los retos de programacion de Mourev para este 2024 y actualice los anteriores para que digan 2023.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ Finalmente te dejo algunas lecturas y videos que ofrecen consejos y experiencias
 - [Podcast: DevRock de Jonatan Ariste](https://open.spotify.com/show/5uRPZ5r7bRkW29c5AkppXq)
 
 ### 🛠️ Desafíos técnicos
-- [Repositorio: Desafíos de código de la comunidad de MoureDev](https://github.com/mouredev/Code-Challenges)
-  
+- [(2023) Repositorio: Desafíos de código de la comunidad de MoureDev](https://github.com/mouredev/Code-Challenges)
+- [(2024) Repositorio: Roadmap retos de programación de la comunidad de MoureDev](https://github.com/mouredev/roadmap-retos-programacion)
+
 En proceso 😊
 
 ---


### PR DESCRIPTION
Actualización de los retos de programación y colocación del año en que se llevaron a cabo los pasados.

- Los que se tenían pertenecen a los retos del 2023, pero igual los considero muy valiosos para dejarlos aún.
- Agregue el nuevo repositorio de los retos que se están llevando a cabo este 2024.